### PR TITLE
remove additional params separator

### DIFF
--- a/lib/mod.lua
+++ b/lib/mod.lua
@@ -507,7 +507,6 @@ local function init_params()
                       end
   end)
 
-  params:add_separator()
 
   if gridkeys_modes[default_mode] ~= 'q7' then
     params:hide("gridkeys_q7_layout")


### PR DESCRIPTION
given current conventions/ patterns of norns script parameters, this separator creates an extra separator in the norns parameters. 